### PR TITLE
pr: Don't output a list

### DIFF
--- a/cmd/wait-for-github/pr.go
+++ b/cmd/wait-for-github/pr.go
@@ -117,12 +117,10 @@ func checkPRMerged(c *cli.Context) error {
 		if mergedCommit != "" {
 			log.Info("PR is merged, exiting")
 			if commitInfoFile != "" {
-				commit := []commitInfo{
-					{
-						Owner:  prConf.owner,
-						Repo:   prConf.repo,
-						Commit: mergedCommit,
-					},
+				commit := commitInfo{
+					Owner:  prConf.owner,
+					Repo:   prConf.repo,
+					Commit: mergedCommit,
 				}
 
 				jsonCommit, err := json.MarshalIndent(commit, "", "  ")


### PR DESCRIPTION
We're watching for a PR, it's only ever going to be one (new head) commit. Not much sense outputting a list. This makes consuming the result a bit easier.