### PR TITLE
ci: Add ability to wait for specific checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ USAGE:
    wait-for-github ci [command options] <https://github.com/OWNER/REPO/commit/HASH|owner> [<repo> <ref>]
 
 OPTIONS:
+   --check value, -c value [ --check value, -c value ]  Check the status of a specific CI check. By default, the status of all checks is checked.
    --help, -h  show help (default: false)
 ```
 This command will wait for CI checks to finish for a ref. If they finish successfully it will exit `0` and otherwise it will exit `1`.


### PR DESCRIPTION
Sometimes status checks are not reported immediately, for example in the case where a webhook request is sent and the receiver is responsible for deciding whether to create it. Just waiting for the overall CI status does not necessarily guarantee that all eventual checks have been created and have reported their result.

Add a new commandline flag to wait for a specific check to have a result. This flag can be given multiple times to wait for multiple statuses.

There are two types of checks in the world of GitHub: checks and statuses. We check for both so it doesn't matter when you give the flag which kind of check you're looking for.