### PR TITLE
Capture timestamp when PR was merged

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ USAGE:
    wait-for-github pr [command options] <https://github.com/OWNER/REPO/pulls/PR|owner> [<repo> <pr>]
 
 OPTIONS:
-   --help, -h  show help (default: false)
+   --commit-info-file value  Path to a file which the commit info will be written. The file will be overwritten if it already exists.
+   --help, -h                show help
 ```
 
 This command will wait for the given PR (URL or owner/repo/number) to be merged

--- a/cmd/wait-for-github/pr.go
+++ b/cmd/wait-for-github/pr.go
@@ -90,9 +90,10 @@ func parsePRArguments(c *cli.Context) error {
 }
 
 type commitInfo struct {
-	Owner  string `json:"owner"`
-	Repo   string `json:"repo"`
-	Commit string `json:"commit"`
+	Owner    string `json:"owner"`
+	Repo     string `json:"repo"`
+	Commit   string `json:"commit"`
+	MergedAt int64  `json:"mergedAt"`
 }
 
 func checkPRMerged(c *cli.Context) error {
@@ -109,7 +110,7 @@ func checkPRMerged(c *cli.Context) error {
 	commitInfoFile := c.String("commit-info-file")
 
 	checkPRMergedOrClosed := func() error {
-		mergedCommit, closed, err := githubClient.IsPRMergedOrClosed(ctx, prConf.owner, prConf.repo, prConf.pr)
+		mergedCommit, closed, mergedAt, err := githubClient.IsPRMergedOrClosed(ctx, prConf.owner, prConf.repo, prConf.pr)
 		if err != nil {
 			return err
 		}
@@ -118,9 +119,10 @@ func checkPRMerged(c *cli.Context) error {
 			log.Info("PR is merged, exiting")
 			if commitInfoFile != "" {
 				commit := commitInfo{
-					Owner:  prConf.owner,
-					Repo:   prConf.repo,
-					Commit: mergedCommit,
+					Owner:    prConf.owner,
+					Repo:     prConf.repo,
+					Commit:   mergedCommit,
+					MergedAt: mergedAt,
 				}
 
 				jsonCommit, err := json.MarshalIndent(commit, "", "  ")

--- a/cmd/wait-for-github/root.go
+++ b/cmd/wait-for-github/root.go
@@ -115,6 +115,7 @@ func handleGlobalConfig(c *cli.Context) error {
 	token := c.String("github-token")
 	if token != "" {
 		log.Debug("Using GitHub token for authentication")
+		log.Debug("Using token starting with ", token[:10], "...")
 		cfg.AuthInfo.GithubToken = token
 
 		return nil


### PR DESCRIPTION
This attribute is important for my use-case because I need to reference the time before a PR was merged.

Also, the `commit-info-file` flag was missing from the docs, so I added it in a drive-by refactor.