### PR TITLE
github: Fix HTTP client when using token

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -65,8 +65,8 @@ func AuthenticateWithToken(ctx context.Context, token string) GithubClient {
 	src := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: token},
 	)
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, &http.Client{Transport: httpcache.NewMemoryCacheTransport()})
 	httpClient := oauth2.NewClient(ctx, src)
-	httpClient.Transport = httpcache.NewMemoryCacheTransport()
 	githubClient := github.NewClient(httpClient)
 
 	return &GHClient{client: githubClient}


### PR DESCRIPTION
I was overwriting the Transport when trying to use a cache. It meant that the token wasn't being used for requests, which is no good.

Closes: #26