### PR TITLE
Add golangci-lint action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,21 @@
+name: golangci-lint
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.17'
+          cache: false
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.17'
+          go-version: '1.20'
           cache: false
       - uses: actions/checkout@v3
       - name: golangci-lint

--- a/cmd/wait-for-github/pr.go
+++ b/cmd/wait-for-github/pr.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strconv"
 
@@ -131,7 +131,7 @@ func checkPRMerged(c *cli.Context) error {
 				}
 
 				log.Debugf("Writing commit info to file %s", commitInfoFile)
-				if err := ioutil.WriteFile(commitInfoFile, jsonCommit, 0644); err != nil {
+				if err := os.WriteFile(commitInfoFile, jsonCommit, 0644); err != nil {
 					return fmt.Errorf("failed to write commit info to file: %w", err)
 				}
 			}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/wait-for-github
 
-go 1.19
+go 1.20
 
 require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.3.0


### PR DESCRIPTION
Just using the default settings. I went for the action rather than adding to the Drone pipeline because then [you get annotations on PRs pointing to the code](https://github.com/golangci/golangci-lint-action). Don't feel that strongly about that though, so lmk what you think.

I also fixed the problem which it found.