### PR TITLE
drone: Don't mount docker credentials for PRs

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6,12 +6,8 @@ steps:
   name: build + test
   settings:
     dry_run: true
-    password:
-      from_secret: docker-hub-password
     repo: grafana/wait-for-github
     tags: latest
-    username:
-      from_secret: docker-hub-username
 trigger:
   event:
     include:
@@ -77,6 +73,6 @@ kind: secret
 name: docker-hub-password
 ---
 kind: signature
-hmac: 3657b20776f15dae625318706c23e4395002fdd94a83385a487cb6009da3d631
+hmac: 367cfc30f5220155a7f1c158300e45ee20d0d9cae5287d12c710e3ae752e31c8
 
 ...

--- a/jsonnet/drone.jsonnet
+++ b/jsonnet/drone.jsonnet
@@ -24,14 +24,8 @@ local pipelines = {
       step.new('build + test', image=images.drone_plugin)
       + step.withSettings({
         dry_run: true,
-        password: {
-          from_secret: 'docker-hub-password',
-        },
         repo: image_to_push,
         tags: 'latest',
-        username: {
-          from_secret: 'docker-hub-username',
-        },
       }),
     ])
     + pipeline.trigger.onModifiedPaths(modified_paths)


### PR DESCRIPTION
We don't need them there, we're only pulling from public repos. They're only needed to push when PRs are merged to main.

The only reason to maybe have wanted them would be to get the higher rate limits it gives. Hopefully that's not needed.