### PR TITLE
Add support for using a PR URL instead of commit SHA

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,12 +109,12 @@ Default is `30s`.
 #### `owner`
 
 GitHub repo owner. Optional. Default is the current repository's owner,
-`${{ github.repository_owner }}`. Ignored when a URL is used for `ref`.
+`${{ github.repository_owner }}`.
 
 #### `repo`
 
 GitHub repo name. Optional. Default is the current repository, 
-`${{ github.event.repository.name }}`. Ignored when a URL is used for `ref`.
+`${{ github.event.repository.name }}`.
 
 #### `token`
 

--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ NAME:
    wait-for-github ci - Wait for CI to be finished
 
 USAGE:
-   wait-for-github ci [command options] <https://github.com/OWNER/REPO/commit/HASH|owner> [<repo> <ref>]
+   wait-for-github ci [command options] <https://github.com/OWNER/REPO/commit|pull/HASH|PRNumber|owner> [<repo> <ref>]
 
 OPTIONS:
-   --check value, -c value [ --check value, -c value ]  Check the status of a specific CI check. By default, the status of all checks is checked. [$GITHUB_CI_CHECKS]
+   --check value, -c value [ --check value, -c value ]  Check the status of a specific CI check. By default, the status of all required checks is checked. [$GITHUB_CI_CHECKS]
    --help, -h  show help (default: false)
 ```
 
-This command will wait for CI checks to finish for a ref. If they finish
+This command will wait for CI checks to finish for a ref or PR URL. If they finish
 successfully it will exit `0` and otherwise it will exit `1`.
 
 ## Action
@@ -101,20 +101,20 @@ checks on the repository. Only used when `wait-for` is set to `"ci"`. Optional.
 If not set, all checks will be waited for, but then the tool may miss checks
 which are not added immediately.
 
-#### `owner`
-
-GitHub repo owner. Optional. Default is the current repository's owner,
-`${{ github.repository_owner }}`.
-
 #### `interval`
 
 Recheck interval (i.e. poll this often) in golang duration format. Optional.
 Default is `30s`.
 
+#### `owner`
+
+GitHub repo owner. Optional. Default is the current repository's owner,
+`${{ github.repository_owner }}`. Ignored when a URL is used for `ref`.
+
 #### `repo`
 
 GitHub repo name. Optional. Default is the current repository, 
-`${{ github.event.repository.name }}`.
+`${{ github.event.repository.name }}`. Ignored when a URL is used for `ref`.
 
 #### `token`
 

--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,6 @@ runs:
     - --recheck-interval
     - ${{ inputs.interval }}
     - ${{ inputs.wait-for }}
-    - ${{ inputs.owner}}
+    - ${{ inputs.owner }}
     - ${{ inputs.repo }}
     - ${{ inputs.ref }}

--- a/cmd/wait-for-github/ci_test.go
+++ b/cmd/wait-for-github/ci_test.go
@@ -185,6 +185,15 @@ func TestParseCIArguments(t *testing.T) {
 			},
 		},
 		{
+			name: "Valid PR URL",
+			args: []string{"https://github.com/owner/repo/pull/1234"},
+			want: ciConfig{
+				owner: "owner",
+				repo:  "repo",
+				ref:   "refs/pull/1234/head",
+			},
+		},
+		{
 			name: "Valid arguments owner, repo, ref",
 			args: []string{"owner", "repo", "abc123"},
 			want: ciConfig{
@@ -196,7 +205,7 @@ func TestParseCIArguments(t *testing.T) {
 		{
 			name:    "Invalid commit URL",
 			args:    []string{"https://invalid_url"},
-			wantErr: ErrInvalidCommitURL{},
+			wantErr: ErrInvalidURL{},
 		},
 		{
 			name:    "Invalid number of arguments",

--- a/cmd/wait-for-github/pr.go
+++ b/cmd/wait-for-github/pr.go
@@ -65,6 +65,18 @@ func (e ErrInvalidPRURL) Error() string {
 	return fmt.Sprintf("invalid pull request URL: %s", e.url)
 }
 
+func extractNumberFromPrURL(url string) (owner, repo, number string) {
+	match := pullRequestRegexp.FindStringSubmatch(url)
+	if match == nil {
+		return owner, repo, number
+	}
+
+	owner = match[1]
+	repo = match[2]
+	number = match[3]
+	return owner, repo, number
+}
+
 func parsePRArguments(c *cli.Context) (prConfig, error) {
 	var owner, repo, number string
 
@@ -72,14 +84,11 @@ func parsePRArguments(c *cli.Context) (prConfig, error) {
 	// If a single argument is provided, it is expected to be a pull request URL
 	case c.NArg() == 1:
 		url := c.Args().Get(0)
-		match := pullRequestRegexp.FindStringSubmatch(url)
-		if match == nil {
+		owner, repo, number = extractNumberFromPrURL(url)
+
+		if len(number) == 0 {
 			return prConfig{}, ErrInvalidPRURL{url}
 		}
-
-		owner = match[1]
-		repo = match[2]
-		number = match[3]
 	// If three arguments are provided, they are expected to be owner, repo, and PR number
 	case c.NArg() == 3:
 		owner = c.Args().Get(0)


### PR DESCRIPTION
This allows us to check the status the status of the HEAD of a PR by just knowing the PR number.