### PR TITLE
Go 1.22 & cleanups

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+[*]
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.yml]
+quote_type = double

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,11 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
 
-      - uses: docker/setup-buildx-action@v3
+      - name: Set Docker Buildx up
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
 
       - name: Build Docker image
         uses: grafana/shared-workflows/actions/build-push-to-dockerhub@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
     paths:
       - go.mod
       - go.sum
-      - '**/*.go'
+      - "**/*.go"
       - Dockerfile
       - .github/workflows/build.yml
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,9 +12,13 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - name: Checkout
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+
+      - name: Setup Go toolchain
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version-file: "./go.mod"
+
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804 # v4.0.0

--- a/action.yml
+++ b/action.yml
@@ -2,46 +2,46 @@ name: Wait for GitHub
 description: Wait for things to happen on GitHub
 inputs:
   token:
-    description: 'GitHub token'
+    description: "GitHub token"
     required: false
     default: ${{ github.token }}
   app-id:
-    description: 'GitHub App ID'
+    description: "GitHub App ID"
     required: false
   app-installation-id:
-    description: 'GitHub App installation ID'
+    description: "GitHub App installation ID"
     required: false
   app-private-key:
-    description: 'GitHub App private key'
+    description: "GitHub App private key"
     required: false
   timeout:
-    description: 'Timeout in golang duration format'
+    description: "Timeout in golang duration format"
     required: false
     default: 5m
   interval:
-    description: 'Recheck interval (poll this often) in golang duration format'
+    description: "Recheck interval (poll this often) in golang duration format"
     required: false
     default: 30s
   wait-for:
     description: 'What to wait for. Valid values: "ci" (wait for CI to finish), "pr" (wait for PR to be merged)'
     required: true
   owner:
-    description: 'GitHub repo owner'
+    description: "GitHub repo owner"
     required: false
     default: ${{ github.repository_owner }}
   repo:
-    description: 'GitHub repo name'
+    description: "GitHub repo name"
     required: false
     default: ${{ github.event.repository.name }}
   ref:
-    description: 'Git ref to check'
+    description: "Git ref to check"
     required: true
   checks-to-wait-for:
     description: 'The comma-separated names of the checks to wait for. Only used when wait-for is "ci"'
     required: false
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: "docker"
+  image: "Dockerfile"
   env:
     GITHUB_TOKEN: ${{ inputs.token }}
     GITHUB_CI_CHECKS: ${{ inputs.checks-to-wait-for }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/grafana/wait-for-github
 
-go 1.21
+go 1.22
+
+toolchain go1.22.2
 
 require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.10.0


### PR DESCRIPTION
See the individual commits - some cleanups.

The main one I _want_ here is the go 1.22 bump, because CodeQL is warning about the `toolchain` not being there, and I'm not sure if that is preventing it from running.