### PR TITLE
Improve wait-for-ci failure message

### DIFF
--- a/cmd/wait-for-github/ci_test.go
+++ b/cmd/wait-for-github/ci_test.go
@@ -75,7 +75,7 @@ func TestHandleCIStatus(t *testing.T) {
 		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
-			output := handleCIStatus(tt.status, 1)
+			output := handleCIStatus(tt.status, 1, "")
 			if tt.expectedExitCode == nil {
 				require.Nil(t, output)
 			} else {
@@ -230,4 +230,16 @@ func TestParseCIArguments(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestUrlFor(t *testing.T) {
+	t.Parallel()
+
+	owner := "owner"
+	repo := "repo"
+	ref := "abc123"
+
+	url := urlFor(owner, repo, ref)
+
+	require.Equal(t, "https://github.com/owner/repo/commit/abc123", url)
 }

--- a/cmd/wait-for-github/ci_test.go
+++ b/cmd/wait-for-github/ci_test.go
@@ -47,17 +47,22 @@ func TestHandleCIStatus(t *testing.T) {
 	tests := []struct {
 		name             string
 		status           github.CIStatus
+		url              string
 		expectedExitCode *int
+		expectedError    string
 	}{
 		{
 			name:             "passed",
 			status:           github.CIStatusPassed,
 			expectedExitCode: &zero,
+			expectedError:    "CI successful",
 		},
 		{
 			name:             "failed",
 			status:           github.CIStatusFailed,
+			url:              "https://example.com",
 			expectedExitCode: &one,
+			expectedError:    "CI failed. Please check CI on the following commit: https://example.com",
 		},
 		{
 			name:             "pending",
@@ -75,12 +80,14 @@ func TestHandleCIStatus(t *testing.T) {
 		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
-			output := handleCIStatus(tt.status, 1, "")
+			output := handleCIStatus(tt.status, 1, tt.url)
+
 			if tt.expectedExitCode == nil {
 				require.Nil(t, output)
 			} else {
 				require.NotNil(t, output)
 				require.Equal(t, *tt.expectedExitCode, output.ExitCode())
+				require.Equal(t, tt.expectedError, output.Error())
 			}
 		})
 	}


### PR DESCRIPTION
Recently while debugging a Tempo deployment issue I was confused by the error message "CI failed" in the logs. It seems obvious in retrospect, but it did not occur to me that Tempo's CI had failed or where it had failed.

This PR extends the error message with a link to the commit that is currently failing to help speed up diagnosis of similar issues and reduce confusion.