### PR TITLE
go.mod: Fix `go` format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/grafana/wait-for-github
 
-go 1.22
-
-toolchain go1.22.2
+go 1.22.2
 
 require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.10.0


### PR DESCRIPTION
[CodeQL is still telling us that this file is wrong][warning]. Upon closer reading of [the docs on the file format][docs], `go 1.22` is not valid since `1.22` was not a release of Go. We need to specify a release which existed here, and not a minor version of the language which was what I thought this was before.

Fix it to `go 1.22.2`. Since that is equal to what we had in `toolchain`, the `toolchain` line is no longer needed: delete it.

[docs]: https://tip.golang.org/doc/toolchain#version
[warning]: https://github.com/grafana/wait-for-github/actions/runs/8875865988/job/24366210697