### PR TITLE
ci: Don't want forever when there are no statuses

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/wait-for-github
 
-go 1.22.2
+go 1.22.4
 
 require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.11.0


### PR DESCRIPTION
When there are no statuses on a reference, [GitHub will report the combined status as `pending`][docs]. This is because status checks can be added at any time, and so it's not possible to know if the remote end just hasn't started its check yet, so they play it safe.

That doesn't work for us, though - we need to exit in a finite amount of time. Currently we don't. With this change, we'll check if there were any statuses reported if the combined status is `pending`. If there are, then we really are pending. If there aren't, we will wait for 5 seconds, look again and if it's still empty then we will say the commit passed CI. If something has changed then we return "Unknown" and we'll get called again in due course to see what happened and report the right thing next time.

Here's our real testcase, which failed before (ran forever):

```console
laney@melton [iainlane/wait-for-ci-fix-no-pending-tests|…1]> GITHUB_TOKEN=$(gh auth token) go run  ./... -l debug ci https://github.com/grafana/pyroscope/commit/3fb6d31287dceeb83054f47a23a24d57fdb17ab3
DEBU[2024-07-01 17:38:23] Debug logging enabled                        
DEBU[2024-07-01 17:38:23] Will use GitHub token for authentication     
DEBU[2024-07-01 17:38:23] Using token starting with gho_PvEFZJ...      
DEBU[2024-07-01 17:38:23] Using GitHub token for authentication        
INFO[2024-07-01 17:38:23] Checking CI status on grafana/pyroscope@3fb6d31287dceeb83054f47a23a24d57fdb17ab3 
2024/07/01 17:38:23 [DEBUG] GET https://api.github.com/repos/grafana/pyroscope/commits/3fb6d31287dceeb83054f47a23a24d57fdb17ab3/status?per_page=100
INFO[2024-07-01 17:38:23] No statuses found, waiting for a bit to see if one appears 
2024/07/01 17:38:28 [DEBUG] GET https://api.github.com/repos/grafana/pyroscope/commits/3fb6d31287dceeb83054f47a23a24d57fdb17ab3/status?per_page=100
DEBU[2024-07-01 17:38:28] No statuses found after waiting, assuming success 
CI successful
```

[docs]: https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#get-the-combined-status-for-a-specific-reference
