### PR TITLE
github: Process all pages of results

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/wait-for-github
 
-go 1.22.4
+go 1.22.5
 
 require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.11.0


### PR DESCRIPTION
We've come across some cases now where there are over 100 statuses. In that case, as 21247305c86ad1a97fa67b9db4473ef478db4898 shows, we don't find what we're looking for.

The `go-github` package fully supports pagination, we simply weren't using it. Here we update to use it and fix the issue.

I pushed 21247305c86ad1a97fa67b9db4473ef478db4898 first. See CI on that commit for the failure, and then we can see how it passes with the latest commit here.

We also had a real failure internally that I verified is now fixed, but I can't share it here I'm afraid, as it's a private repo.