### PR TITLE
configurable pending recheck interval

### DIFF
--- a/cmd/wait-for-github/ci.go
+++ b/cmd/wait-for-github/ci.go
@@ -216,7 +216,7 @@ func ciCommand(cfg *config) *cli.Command {
 			return err
 		},
 		Action: func(c *cli.Context) error {
-			githubClient, err := github.NewGithubClient(c.Context, cfg.AuthInfo)
+			githubClient, err := github.NewGithubClient(c.Context, cfg.AuthInfo, cfg.pendingRecheckTime)
 			if err != nil {
 				return err
 			}

--- a/cmd/wait-for-github/config.go
+++ b/cmd/wait-for-github/config.go
@@ -25,5 +25,6 @@ import (
 type config struct {
 	github.AuthInfo
 	recheckInterval time.Duration
+	pendingRecheckTime time.Duration
 	globalTimeout   time.Duration
 }

--- a/cmd/wait-for-github/pr.go
+++ b/cmd/wait-for-github/pr.go
@@ -227,7 +227,7 @@ func prCommand(cfg *config) *cli.Command {
 			return err
 		},
 		Action: func(c *cli.Context) error {
-			githubClient, err := github.NewGithubClient(c.Context, cfg.AuthInfo)
+			githubClient, err := github.NewGithubClient(c.Context, cfg.AuthInfo, cfg.pendingRecheckTime)
 			if err != nil {
 				return err
 			}

--- a/cmd/wait-for-github/root.go
+++ b/cmd/wait-for-github/root.go
@@ -95,7 +95,7 @@ func root() *cli.App {
 				Name:    "pending-recheck-time",
 				Usage:   "Time after which to recheck the pending status on GitHub.",
 				EnvVars: []string{"PENDING_RECHECK_TIME"},
-				Value:   5 * time.Second, // default value
+				Value:   5 * time.Second,
 			},
 			&cli.DurationFlag{
 				Name:    "timeout",

--- a/cmd/wait-for-github/root.go
+++ b/cmd/wait-for-github/root.go
@@ -92,6 +92,12 @@ func root() *cli.App {
 				Value:   time.Duration(30 * time.Second),
 			},
 			&cli.DurationFlag{
+				Name:    "pending-recheck-time",
+				Usage:   "Time after which to recheck the pending status on GitHub.",
+				EnvVars: []string{"PENDING_RECHECK_TIME"},
+				Value:   5 * time.Second, // default value
+			},
+			&cli.DurationFlag{
 				Name:    "timeout",
 				Usage:   "Timeout after which to stop checking GitHub.",
 				EnvVars: []string{"TIMEOUT"},
@@ -135,6 +141,7 @@ func handleGlobalConfig(c *cli.Context) (config, error) {
 	cfg := config{}
 
 	cfg.recheckInterval = c.Duration("recheck-interval")
+	cfg.pendingRecheckTime = c.Duration("pending-recheck-time")
 	cfg.globalTimeout = c.Duration("timeout")
 
 	token := c.String("github-token")

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -60,25 +60,8 @@ type AuthInfo struct {
 	GithubToken string
 }
 
-// sleeper is a type that can sleep for a duration. It's used to allow for
-// mocking sleep in tests. By default, it uses `time.Sleep`, but it can be
-// initialised with a custom sleep function which will be called if set.
-type sleeper struct {
-	doSleep func(time.Duration)
-}
-
-func (s *sleeper) sleep(d time.Duration) {
-	if s != nil {
-		s.doSleep(d)
-		return
-	}
-
-	time.Sleep(d)
-}
-
 type GHClient struct {
 	client  *github.Client
-	sleeper *sleeper
 	pendingRecheckTime time.Duration
 }
 
@@ -210,7 +193,7 @@ func (c GHClient) GetCIStatus(ctx context.Context, owner, repoName string, ref s
 		// and then check again.
 		if len(status.Statuses) == 0 {
 			log.Infof("No statuses found, waiting %s to see if one appears", c.pendingRecheckTime)
-			c.sleeper.sleep(c.pendingRecheckTime)
+			time.Sleep(c.pendingRecheckTime)
 
 			status, _, err = c.client.Repositories.GetCombinedStatus(ctx, owner, repoName, ref, nil)
 			if err != nil {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -44,8 +44,9 @@ func TestNewGithubClientWithToken(t *testing.T) {
 	authInfo := AuthInfo{
 		GithubToken: "my-token",
 	}
+	pendingRecheckTime := 1 * time.Second
 
-	githubClient, err := NewGithubClient(ctx, authInfo)
+	githubClient, err := NewGithubClient(ctx, authInfo, pendingRecheckTime)
 	require.NoError(t, err)
 
 	if githubClient.client == nil {
@@ -81,8 +82,9 @@ func TestNewGithubClientWithAppAuthentication(t *testing.T) {
 		// generate this with: openssl genrsa 32 2>/dev/null | awk 1 ORS='\\n'
 		PrivateKey: []byte("-----BEGIN RSA PRIVATE KEY-----\nMC0CAQACBQD7J5Q9AgMBAAECBB6C8NkCAwD+JwIDAPz7AgMA1xcCAkoZAgMAwE8=\n-----END RSA PRIVATE KEY-----"),
 	}
+	pendingRecheckTime := 1 * time.Second
 
-	githubClient, err := NewGithubClient(ctx, authInfo)
+	githubClient, err := NewGithubClient(ctx, authInfo, pendingRecheckTime)
 	require.NoError(t, err)
 
 	if githubClient.client == nil {
@@ -120,6 +122,7 @@ func newClientFromMock(t *testing.T, mockClient *http.Client) *GHClient {
 	return &GHClient{
 		client:  github.NewClient(httpClient),
 		sleeper: &sleeper{func(_ time.Duration) {}},
+		pendingRecheckTime: 1 * time.Second,
 	}
 }
 

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -121,8 +121,7 @@ func newClientFromMock(t *testing.T, mockClient *http.Client) *GHClient {
 
 	return &GHClient{
 		client:  github.NewClient(httpClient),
-		sleeper: &sleeper{func(_ time.Duration) {}},
-		pendingRecheckTime: 1 * time.Second,
+		pendingRecheckTime: 0 * time.Second,
 	}
 }
 


### PR DESCRIPTION
Recently a pending recheck time was introduced: https://github.com/grafana/wait-for-github/pull/144
Though reasons behind this PR sound absolutely reasonable, we've found that the current hard-coded time is not enough in our setup.
So, I think it might be worth making this parameter configurable by users.
In this PR I've added a new flag `--pending-recheck-time` that controls recheck delay.
I'm not confident with golang, so please, let me know if I can make something better.