### PR TITLE
ci: add scorecard action to assess project health

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,5 @@
 name: Build
 
-permissions:
-  contents: read
-  id-token: write
-
 on:
   pull_request:
     types:
@@ -26,10 +22,16 @@ on:
 
 jobs:
   main:
+    permissions:
+      contents: read
+      id-token: write
+
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set Docker Buildx up
         uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,14 +3,14 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
-
 name: release-please
 
 jobs:
   release-please:
+    permissions:
+      contents: write
+      pull-requests: write
+
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # v4.1.3

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,22 @@
+name: Zizmor GitHub Actions static analysis
+on:
+  pull_request:
+
+  push:
+    branches:
+      - main
+
+jobs:
+  scorecard:
+    name: Analyse
+
+    permissions:
+      actions: read
+      contents: read
+
+      pull-requests: write
+      security-events: write
+
+    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@f60c930303680d858b87d19385129998fb479a31
+    with:
+      fail-severity: any


### PR DESCRIPTION
We can generate an [OpenSSF scorecard][scorecard] by including the GitHub Action. And thereby we'll get regularly checked on a [whole bunch of metrics][checks].

[checks]: https://github.com/ossf/scorecard#scorecard-checks
[scorecard]: https://github.com/ossf/scorecard