### PR TITLE
feat(ci): modify GetCIStatus to utilize GitHub GraphQL API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/migueleliasweb/go-github-mock v1.1.0
+	github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.10.0
 	github.com/urfave/cli/v2 v2.27.5

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466 h1:17JxqqJY66GmZVHkmAsGEkcIu0oCe3AM420QDgGwZx0=
+github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466/go.mod h1:9dIRpgIY7hVhoqfe0/FcYp0bpInZaT7dc3BYOprrIUE=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
This API allows us to get both checks and statuses in one call, and gives us an overall status of all the CI checks. This means we can get rid of the `getCIChecksResult` and `getCombinedStatus` functions. Additionally, `GetCIStatus` will now individually log any failed checks or statuses from the query.

Here are some results from testing:

- Query on commit with statuses & checks
```
DEBU[2025-01-14 16:34:32] Debug logging enabled                        
DEBU[2025-01-14 16:34:32] Will use GitHub token for authentication     
DEBU[2025-01-14 16:34:32] Using token starting with ghp_8kXW80...      
DEBU[2025-01-14 16:34:32] Using GitHub token for authentication        
INFO[2025-01-14 16:34:32] Checking CI status on dblinkhorn/wait-for-github-graphql-test@23c27195d5172ddf9a4bef27243370e428548189 
2025/01/14 16:34:32 [DEBUG] POST https://api.github.com/graphql
CI successful
```

- Querying a repo without statuses or checks
```
DEBU[2025-01-14 16:25:43] Debug logging enabled                        
DEBU[2025-01-14 16:25:43] Will use GitHub token for authentication     
DEBU[2025-01-14 16:25:43] Using token starting with ghp_8kXW80...      
DEBU[2025-01-14 16:25:43] Using GitHub token for authentication        
INFO[2025-01-14 16:25:43] Checking CI status on dblinkhorn/wait-for-github-graphql-test@8861c74e96251fac19cf94305c9ca0475b451d0c 
2025/01/14 16:25:43 [DEBUG] POST https://api.github.com/graphql
INFO[2025-01-14 16:25:43] Did not find any checks and/or statuses. Retrying in 5s to see if any appear 
2025/01/14 16:25:48 [DEBUG] POST https://api.github.com/graphql
DEBU[2025-01-14 16:25:48] No checks or statuses found after retry, assuming success 
CI successful
```

- Querying commit with a failed check & status
```
DEBU[2025-01-14 16:04:43] Debug logging enabled                        
DEBU[2025-01-14 16:04:43] Will use GitHub token for authentication     
DEBU[2025-01-14 16:04:43] Using token starting with ghp_8kXW80...      
DEBU[2025-01-14 16:04:43] Using GitHub token for authentication        
INFO[2025-01-14 16:04:43] Checking CI status on dblinkhorn/wait-for-github-graphql-test@63dd76c531777f14d2614cf3642b3316004d8ffb 
2025/01/14 16:04:43 [DEBUG] POST https://api.github.com/graphql
DEBU[2025-01-14 16:04:43] CI failed. Failed nodes:                     
DEBU[2025-01-14 16:04:43] CheckRun 'build' failed                      
DEBU[2025-01-14 16:04:43] StatusContext 'security-check' failed        
CI failed. Please check CI on the following commit: https://github.com/dblinkhorn/wait-for-github-graphql-test/commit/63dd76c531777f14d2614cf3642b3316004d8ffb
```

- Query commit with skipped check
```
DEBU[2025-01-14 16:39:01] Debug logging enabled                        
DEBU[2025-01-14 16:39:01] Will use GitHub token for authentication     
DEBU[2025-01-14 16:39:01] Using token starting with ghp_8kXW80...      
DEBU[2025-01-14 16:39:01] Using GitHub token for authentication        
INFO[2025-01-14 16:39:01] Checking CI status on dblinkhorn/wait-for-github-graphql-test@b6f92ebb708854dbb9cd5ce1333e081a9e9cc943 
2025/01/14 16:39:01 [DEBUG] POST https://api.github.com/graphql
CI successful
```

- Immediately query for CI status after a new commit is pushed to repo
```
$ git push & ~/wait-for-github/wait-for-github --github-token ghp_8***y --log-level debug ci https://github.com/dblinkhorn/wait-for-github-graphql-test/commit/$(git rev-parse HEAD)                    
[1] 6883
DEBU[2025-01-14 16:43:41] Debug logging enabled                        
DEBU[2025-01-14 16:43:41] Will use GitHub token for authentication     
DEBU[2025-01-14 16:43:41] Using token starting with ghp_8kXW80...      
DEBU[2025-01-14 16:43:41] Using GitHub token for authentication        
INFO[2025-01-14 16:43:41] Checking CI status on dblinkhorn/wait-for-github-graphql-test@1f75ceb24f804cebdfdda2e72b7c54a7169c0bc5 
2025/01/14 16:43:41 [DEBUG] POST https://api.github.com/graphql
INFO[2025-01-14 16:43:41] Did not find any checks and/or statuses. Retrying in 5s to see if any appear 
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 177 bytes | 177.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0
To https://github.com/dblinkhorn/wait-for-github-graphql-test.git
   b6f92eb..1f75ceb  main -> main
[1]  + 6883 done       git push
2025/01/14 16:43:46 [DEBUG] POST https://api.github.com/graphql
INFO[2025-01-14 16:43:47] CI is not finished yet, rechecking in 30s    
2025/01/14 16:44:11 [DEBUG] POST https://api.github.com/graphql
CI successful
```