### PR TITLE
docs(permissions): document `actions:read` permission required for counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ key, ID and installtion ID.
 
 The GitHub token or app needs the following permissions:
 
+- `actions:read` - Read names of workflows which ran on a ref
 - `checks:read` - Read check run status and conclusions for CI checks
 - `contents:read` - Access commit data through GitHub's GraphQL API when
   checking CI status


### PR DESCRIPTION
In 0239f23b0729b1ebf2d76786e39a206df2618684 we started retrieving counts and names of workflows which ran in the target repository. I wasn't expecting it to require any more permissions but it seems like this does need `actions:read`. This commit documents that new requirement.
