### PR TITLE
fix(ci): remove recheckInterval from Check interface

### DIFF
--- a/cmd/wait-for-github/ci_test.go
+++ b/cmd/wait-for-github/ci_test.go
@@ -82,7 +82,7 @@ func TestHandleCIStatus(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			output := handleCIStatus(tt.status, 1, tt.url)
+			output := handleCIStatus(tt.status, tt.url)
 
 			if tt.expectedExitCode == nil {
 				require.Nil(t, output)

--- a/cmd/wait-for-github/pr.go
+++ b/cmd/wait-for-github/pr.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"regexp"
 	"strconv"
-	"time"
 
 	"github.com/grafana/wait-for-github/internal/github"
 	"github.com/grafana/wait-for-github/internal/utils"
@@ -143,7 +142,7 @@ type prCheck struct {
 	githubClient checkMergedAndOverallCI
 }
 
-func (pr prCheck) Check(ctx context.Context, recheckInterval time.Duration) error {
+func (pr prCheck) Check(ctx context.Context) error {
 	mergedCommit, closed, mergedAt, err := pr.githubClient.IsPRMergedOrClosed(ctx, pr.owner, pr.repo, pr.pr)
 	if err != nil {
 		return err
@@ -193,7 +192,7 @@ func (pr prCheck) Check(ctx context.Context, recheckInterval time.Duration) erro
 		return cli.Exit("CI failed", 1)
 	}
 
-	log.Infof("PR is not closed yet, rechecking in %s", recheckInterval)
+	log.Infof("PR is not closed yet")
 	return nil
 }
 

--- a/cmd/wait-for-github/pr_test.go
+++ b/cmd/wait-for-github/pr_test.go
@@ -174,7 +174,7 @@ func TestWriteCommitInfoFile(t *testing.T) {
 		},
 	}
 
-	err := prCheck.Check(context.TODO(), 1)
+	err := prCheck.Check(context.TODO())
 	var cliExitErr cli.ExitCoder
 	require.ErrorAs(t, err, &cliExitErr)
 	require.Equal(t, 0, cliExitErr.ExitCode())
@@ -218,7 +218,7 @@ func TestWriteCommitInfoFileError(t *testing.T) {
 		},
 	}
 
-	err := prCheck.Check(context.Background(), 1)
+	err := prCheck.Check(context.Background())
 	require.Error(t, err)
 }
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -29,7 +29,7 @@ import (
 )
 
 type Check interface {
-	Check(ctx context.Context, recheckInterval time.Duration) error
+	Check(ctx context.Context) error
 }
 
 func RunUntilCancelledOrTimeout(ctx context.Context, check Check, interval time.Duration) error {
@@ -40,10 +40,12 @@ func RunUntilCancelledOrTimeout(ctx context.Context, check Check, interval time.
 	signal.Notify(signalChan, syscall.SIGINT)
 
 	for {
-		err := check.Check(ctx, interval)
+		err := check.Check(ctx)
 		if err != nil {
 			return err
 		}
+
+		log.Infof("Rechecking in %s", interval)
 
 		select {
 		case <-ticker.C:

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -15,7 +15,7 @@ type TestCheck struct {
 	fn func() error
 }
 
-func (t *TestCheck) Check(ctx context.Context, recheckInterval time.Duration) error {
+func (t *TestCheck) Check(ctx context.Context) error {
 	return t.fn()
 }
 


### PR DESCRIPTION
- removed `recheckInterval` from the `Check` interface
- updated all `Check` implementations to match the new signature
- removed all downstream references to `recheckInterval` in logs
- moved the 'Rechecking in...' log statement to `RunUntilCancelledOrTimeout`

The downside of this change is that we will now have two separate log lines. One from `RunUntilCancelledOrTimeout` (1st line) and one from other functions that previously logged `recheckInterval` directly.

```
PR is not closed yet
Rechecking in 15s...
```

If this isn't what we want then we could pass a logger function around, but that doesn't seem much different than just passing `recheckInterval` like we currently do.