### PR TITLE
ci: fix lints picked up by zizmor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,5 @@
 name: Build
 
-permissions:
-  contents: read
-  id-token: write
-
 on:
   pull_request:
     types:
@@ -26,6 +22,10 @@ on:
 
 jobs:
   main:
+    permissions:
+      contents: read
+      id-token: write
+
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -35,7 +35,7 @@ jobs:
         uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
 
       - name: Build Docker image
-        uses: grafana/shared-workflows/actions/build-push-to-dockerhub@main
+        uses: grafana/shared-workflows/actions/build-push-to-dockerhub@402975d84dd3fac9ba690f994f412d0ee2f51cf4 # build-push-to-dockerhub-v0.1.1
         with:
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -65,7 +65,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0 # v3.28.9
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -93,6 +93,7 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0 # v3.28.9
+
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,14 +3,14 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
-
 name: release-please
 
 jobs:
   release-please:
+    permissions:
+      contents: write
+      pull-requests: write
+
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # v4.1.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,20 @@
-FROM golang:1.24.0-alpine AS builder
+FROM --platform=${BUILDPLATFORM} golang:1.24.0-alpine3.21@sha256:2d40d4fc278dad38be0777d5e2a88a2c6dee51b0b29c97a764fc6c6a11ca893c AS builder
 
 WORKDIR /go/src/app
+
+COPY go.mod go.sum ./
+RUN <<EOF
+  go mod download
+  go mod verify
+EOF
+
 COPY . .
 
 RUN go get -d -v ./...
 RUN CGO_ENABLED=0 go test -v ./...
 RUN CGO_ENABLED=0 go build -o /go/bin/app github.com/grafana/wait-for-github/cmd/wait-for-github
 
-FROM gcr.io/distroless/static-debian11
+FROM gcr.io/distroless/static-debian12@sha256:3f2b64ef97bd285e36132c684e6b2ae8f2723293d09aae046196cca64251acac
 
 COPY --from=builder /go/bin/app /go/bin/app
 


### PR DESCRIPTION
I just ran [zizmor] on the repo. This fixes the lints it found. There's a small improvement to build efficiency too: download the Go dependencies separately. This means they get their own layer in the container build, which can be reused if the deps don't change.

[zizmor]: https://woodruffw.github.io/zizmor/
