### PR TITLE
ci: fix release-please output and context

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,18 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-
+    outputs:
+      release_created: "${{ steps.release-please.outputs.release_created }}"
+      release_tag: "${{ steps.release-please.outputs.tag_name }}"
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          # https://github.com/actions/checkout/issues/1467
+          fetch-depth: 0
       - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0
+        id: release-please
         with:
           config-file: .release-please.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
Release-please needs to operate in the checkout to have access to the configuration and the docker job needs access to the output of release-please.