### PR TITLE
fix: don't share non-thread-safe ANSITransformer instance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM --platform=${BUILDPLATFORM} golang:1.24.4-alpine3.21@sha256:56a23791af0f77c87b049230ead03bd8c3ad41683415ea4595e84ce7eada121a AS builder
 
+# Dependencies required to run the race detector
+RUN apk add --no-cache gcc musl-dev
+
 WORKDIR /go/src/app
 
 COPY go.mod go.sum ./
@@ -11,7 +14,8 @@ EOF
 COPY . .
 
 RUN go get -d -v ./...
-RUN CGO_ENABLED=0 go test -v ./...
+# `go test` requires cgo
+RUN CGO_ENABLED=1 go test -race -v ./...
 RUN CGO_ENABLED=0 go build -o /go/bin/app github.com/grafana/wait-for-github/cmd/wait-for-github
 
 FROM gcr.io/distroless/static-debian12@sha256:d9f9472a8f4541368192d714a995eb1a99bab1f7071fc8bde261d7eda3b667d8

--- a/cmd/wait-for-github/ci_list.go
+++ b/cmd/wait-for-github/ci_list.go
@@ -39,7 +39,6 @@ type checkListConfig struct {
 	githubClient github.GetDetailedCIStatus
 }
 
-var caser = ansi.NewANSITransformer(cases.Title(language.English))
 
 // tableWriter is a wrapper around the tablewriter library, provided so that
 // tests can mock the table writing process
@@ -105,6 +104,7 @@ func listChecks(ctx context.Context, cfg *checkListConfig, table tableWriter) er
 
 	var data [][]string
 	for _, check := range checks {
+		caser := ansi.NewANSITransformer(cases.Title(language.English))
 		checkOutcomeString, _, _ := transform.String(caser, check.Outcome().String())
 
 		data = append(data, []string{


### PR DESCRIPTION
In 7eecb18919b5d1fc98620cbe20d9b2dfc1f3fa8a we introduced support for title casing CI statuses in our output, using the [`text/transform`] package.

This was done using a `caser` instanced, which was defined as a shared (global) `ANSITransformer` instance.

Unfortunately doing this with a global variable opens us up to a race condition which we are triggering with the testsuite. When tests run with `t.Parallel()`, as we do, multiple goroutines simultaneously call `transform.String(caser, ...)` on the single instance. Each modifies the transformer's internal state concurrently, causing data races which result in incorrect results and, in the case of the testsuite, failing tests.

The race detector output showed concurrent read/write access to the same memory location in `ANSITransformer.Reset()`.

Transformers can be fed small chunks of text at a time, and they should still be able to transform correctly. Imagine we're title casing a string "hello world". We could feed "he", "llo w", "orld" in three calls, and the transformer should be able to output "Hello World" correctly. This means that it must be _stateful_. The `Reset()` method's existence implies this too.

Fortunately, fix is straightforward: remove the global variable and create a new transformer instance for each use. Since `ANSITransformer` instances are lightweight and creation is fast, this doesn't really impact performance whilst eliminating the shared mutable state that caused the race condition.

To better be able to detect such bugs in future, add the `-race` flag to the Docker build's test step. This ensures the CI will catch similar concurrency issues in future, rather than them slipping through to be discovered later. The race detector requires `cgo` to be enabled, so we set `CGO_ENABLED=1` on just the `go test` command in the Dockerfile. This also requires a compiler and C libraries, which we install.

[`text/transform`]: https://pkg.go.dev/golang.org/x/text/transform
