### PR TITLE
build(docker): optimise build performance with cache mounts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,39 @@
 FROM --platform=${BUILDPLATFORM} golang:1.24.4-alpine3.21@sha256:56a23791af0f77c87b049230ead03bd8c3ad41683415ea4595e84ce7eada121a AS builder
 
 # Dependencies required to run the race detector
-RUN apk add --no-cache gcc musl-dev
+RUN \
+  --mount=type=cache,target=/var/cache/apk \
+  apk add --no-cache gcc musl-dev
 
 WORKDIR /go/src/app
 
 COPY go.mod go.sum ./
-RUN <<EOF
+RUN \
+  --mount=type=cache,target=/go/pkg/mod <<EOF
   go mod download
   go mod verify
 EOF
 
 COPY . .
 
-RUN go get -d -v ./...
 # `go test` requires cgo
-RUN CGO_ENABLED=1 go test -race -v ./...
-RUN CGO_ENABLED=0 go build -o /go/bin/app github.com/grafana/wait-for-github/cmd/wait-for-github
+RUN \
+  --mount=type=cache,target=/go/pkg/mod \
+  --mount=type=cache,target=/root/.cache/go-build \
+  CGO_ENABLED=1 go test -race -v ./...
+
+RUN \
+  --mount=type=cache,target=/go/pkg/mod \
+  --mount=type=cache,target=/root/.cache/go-build \
+  CGO_ENABLED=0 \
+  GOOS=${TARGETOS} \
+  GOARCH=${TARGETARCH} \
+  \
+  go \
+  build \
+  -ldflags="-w -s" \
+  -o /go/bin/app \
+  github.com/grafana/wait-for-github/cmd/wait-for-github
 
 FROM gcr.io/distroless/static-debian12@sha256:d9f9472a8f4541368192d714a995eb1a99bab1f7071fc8bde261d7eda3b667d8
 


### PR DESCRIPTION
Note: stacked on #279, because I noticed this while working there.

Any change to go.mod previously invalidated Docker's layer cache, causing a full re-download of all dependencies - even if only one package changed.

If we add BuildKit cache mounts for Go modules and build cache, dependencies will be persisted between builds. Now only new or changed packages are downloaded, which will reduce build times. In CI we're already setting the cache flags to use the GitHub Actions cache - this will now take advantage of that, caching dependencies and build outputs between builds.

Also removed the redundant `go get -d` step (`go mod download` does this), and added explicit cross-compilation variables to open up the potential for cross compilation down the line.

Finally, strip debug information from the final binary to reduce the image size.