### PR TITLE
chore: update lint-pr-title to v1.2.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,4 +35,4 @@ jobs:
 
       - name: lint PR title / commit message
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
-        uses: grafana/shared-workflows/actions/lint-pr-title@b48387250d5484d8375a7c1e938915e4b53e04b8 # lint-pr-title-v1.1.1
+        uses: grafana/shared-workflows/actions/lint-pr-title@19d8fb5687bb386849f7f53673c5f429e6387cf5 # lint-pr-title/v1.2.0


### PR DESCRIPTION
This also uses the new tag format which should be handled better by dependabot/renovate.