### PR TITLE
fix(cli): fix `--log-level` flag being ignored

### DIFF
--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -14,7 +14,7 @@ import (
 
 type Level slog.Level
 
-func (l *Level) UnmarshalFlag(value string) error {
+func (l *Level) Set(value string) error {
 	var lvl slog.Level
 	if err := lvl.UnmarshalText([]byte(value)); err != nil {
 		return fmt.Errorf("invalid log level: %w", err)
@@ -23,22 +23,21 @@ func (l *Level) UnmarshalFlag(value string) error {
 	return nil
 }
 
-func (l *Level) Set(value string) error {
-	return l.UnmarshalFlag(value)
+func (l *Level) String() string {
+	return slog.Level(*l).String()
 }
 
-func (l Level) String() string {
-	return slog.Level(l).String()
+func (l *Level) Get() any {
+	return l
 }
 
-func SetupLogger(defaultLevel slog.Level) {
+func SetupLogger(defaultLevel slog.Level) *slog.Logger {
 	var lv slog.LevelVar
 	lv.Set(defaultLevel)
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
 		Level: &lv,
 	}))
-	defer func() { slog.SetDefault(logger) }()
 
 	if os.Getenv("GITHUB_ACTIONS") == "true" {
 		logger = slog.New(&actionslog.Wrapper{
@@ -60,4 +59,6 @@ func SetupLogger(defaultLevel slog.Level) {
 			Level:     &lv,
 		}))
 	}
+
+	return logger
 }


### PR DESCRIPTION
The `--log-level` flag was being completely ignored - even when explicitly provided on the command line, the application would always use the default log level instead of the selected level.

The issue was occurring because `cmd.Generic("log-level")` was returning `nil` in the `Before` hook, even when the flag was provided. This is due to differences in parsing of root / command-specific flags in `urfave/cli` v3.

We've fixed this by implementing a flag action (function that executes when the flag is set), which configures the logger with the user-specified level. This required implementing `flag.Value` rather than `TextUnmarshaler` - again a requirement of `urfave/cli` v3.

The phasing of when things are executed is slightly different now. We have:

1. `Before` hook: initialises the config 2. `Action` handlers for flags which are set on the commandline 3. `Action` handler for the command itself

Because we were setting up the logger in a `Before` hook, we hadn't handled the `--log-level` flag yet. So we've updated to store an `*slog.Logger` instead of using the default logger. This means we can set the field in the config struct directly at any time.

With this, `--log-level` works properly again.
