### PR TITLE
fix: handle rate-limiting more gracefully

### DIFF
--- a/cmd/wait-for-github/pr_test.go
+++ b/cmd/wait-for-github/pr_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io/fs"
 	"testing"
+	"time"
 
 	"github.com/grafana/wait-for-github/internal/github"
 	"github.com/stretchr/testify/require"
@@ -377,6 +378,49 @@ func TestWriteCommitInfoFileError(t *testing.T) {
 
 	err := prCheck.Check(context.Background())
 	require.Error(t, err)
+}
+
+// rateLimitThenMergedClient embeds fakeGithubClientPRCheck but overrides
+// IsPRMergedOrClosed to return a GitHubRateLimitError on the first call and a
+// merged PR on the second, exercising the rate-limit retry path end-to-end.
+type rateLimitThenMergedClient struct {
+	fakeGithubClientPRCheck
+	calls int
+}
+
+func (c *rateLimitThenMergedClient) IsPRMergedOrClosed(ctx context.Context, owner, repo string, pr int) (string, bool, int64, error) {
+	c.calls++
+	if c.calls == 1 {
+		return "", false, 0, &github.GitHubRateLimitError{
+			Operation: "GetPullRequest",
+			ResetTime: time.Now().Add(50 * time.Millisecond),
+		}
+	}
+	return "abc123", false, 1234567890, nil
+}
+
+// TestPRCheckRateLimitRetry verifies that checkPRMerged does not exit with a
+// rate-limit error. It should wait until ResetTime and retry, ultimately
+// returning exit code 0 when the PR is found to be merged.
+func TestPRCheckRateLimitRetry(t *testing.T) {
+	t.Parallel()
+
+	client := &rateLimitThenMergedClient{}
+	cfg := &config{
+		recheckInterval: 10 * time.Millisecond,
+		logger:          testLogger,
+	}
+	prConf := &prConfig{owner: "owner", repo: "repo", pr: 1}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := checkPRMerged(ctx, client, cfg, prConf)
+
+	var exitErr cli.ExitCoder
+	require.ErrorAs(t, err, &exitErr)
+	require.Equal(t, 0, exitErr.ExitCode(), "expected exit code 0 (PR merged), not a rate limit error")
+	require.Equal(t, 2, client.calls, "expected exactly two calls: one rate-limited, one successful")
 }
 
 func TestParsePRArguments(t *testing.T) {

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -324,6 +324,14 @@ func (c GHClient) handleResponseError(resp *github.Response, operation, owner, r
 	return nil
 }
 
+// cachingRetryableTransport returns an HTTP transport that retries transient
+// network errors and 5xx responses, and caches responses in memory.
+//
+// It does not handle GitHub rate-limit responses (HTTP 403/429 with
+// X-RateLimit-* or Retry-After headers) due to the suggested wait times there
+// (minutes and hours).
+//
+// See internal/utils/utils.go for the rate-limit backoffs.
 func cachingRetryableTransport(logger *slog.Logger) http.RoundTripper {
 	retryableClient := retryablehttp.NewClient()
 	retryableClient.Logger = logger

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -77,16 +78,40 @@ func RunUntilCancelledOrTimeout(ctx context.Context, logger *slog.Logger, check 
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, syscall.SIGINT)
 
+	rateLimited := false
+
 	for {
 		err := check.Check(ctx)
 		if err != nil {
-			return err
+			// If this is a rate limiting error, we should consider the
+			// RetryAfter and x-ratelimit-reset headers where present. They
+			// should act as minimum wait time unless interval is already
+			// larger:
+			rle := &github.GitHubRateLimitError{}
+			arle := &github.GitHubAbuseRateLimitError{}
+			if errors.As(err, &rle) {
+				newWait := max(interval, time.Until(rle.ResetTime))
+				ticker.Reset(newWait)
+				logger.InfoContext(ctx, "check was rate limited", "type", "rate-limit", "wait", newWait.String())
+				rateLimited = true
+			} else if errors.As(err, &arle) {
+				newWait := max(interval, arle.RetryAfter)
+				ticker.Reset(newWait)
+				logger.InfoContext(ctx, "check was rate limited", "type", "abuse-rate-limit", "wait", newWait.String())
+				rateLimited = true
+			} else {
+				return err
+			}
 		}
 
 		logger.InfoContext(ctx, "rechecking", "interval", interval)
 
 		select {
 		case <-ticker.C:
+			if rateLimited {
+				ticker.Reset(interval)
+				rateLimited = false
+			}
 		case <-ctx.Done():
 			logger.InfoContext(ctx, "timeout reached, exiting")
 			return cli.Exit("Timeout reached", 1)

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	gh "github.com/grafana/wait-for-github/internal/github"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -90,8 +91,162 @@ func TestInterrupt(t *testing.T) {
 	assert.EqualError(t, err, "Received SIGINT")
 }
 
+// TestPrimaryRateLimitRetries tests that RunUntilCancelledOrTimeout does not
+// return the GitHubRateLimitError, and instead waits at least until ResetTime
+// before retrying.
+func TestPrimaryRateLimitRetries(t *testing.T) {
+	ctx := t.Context()
+	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	interval := 50 * time.Millisecond
+	resetDelay := 200 * time.Millisecond // longer than interval to verify the minimum is honoured
+	var resetTime time.Time
+	var secondCallAt time.Time
+	sentinelErr := fmt.Errorf("sentinel: second call succeeded")
+
+	calls := 0
+	check := &TestCheck{
+		fn: func() error {
+			calls++
+			if calls == 1 {
+				resetTime = time.Now().Add(resetDelay)
+				return &gh.GitHubRateLimitError{
+					ResetTime: resetTime,
+				}
+			}
+			secondCallAt = time.Now()
+			return sentinelErr
+		},
+	}
+
+	err := RunUntilCancelledOrTimeout(timeoutCtx, testLogger, check, interval)
+
+	assert.Equal(t, sentinelErr, err, "expected sentinel error from second call, not the rate limit error")
+	assert.Equal(t, 2, calls)
+	assert.False(t, secondCallAt.Before(resetTime), "second call should not happen before ResetTime")
+}
+
+// TestAbuseRateLimitRespectsRetryAfter tests that RunUntilCancelledOrTimeout
+// waits at least RetryAfter before retrying when RetryAfter exceeds the interval.
+func TestAbuseRateLimitRespectsRetryAfter(t *testing.T) {
+	ctx := t.Context()
+	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	interval := 50 * time.Millisecond
+	retryAfter := 200 * time.Millisecond // longer than interval to verify the minimum is honoured
+	var firstCallAt time.Time
+	var secondCallAt time.Time
+	sentinelErr := fmt.Errorf("sentinel: second call succeeded")
+
+	calls := 0
+	check := &TestCheck{
+		fn: func() error {
+			calls++
+			if calls == 1 {
+				firstCallAt = time.Now()
+				return &gh.GitHubAbuseRateLimitError{
+					RetryAfter: retryAfter,
+				}
+			}
+			secondCallAt = time.Now()
+			return sentinelErr
+		},
+	}
+
+	err := RunUntilCancelledOrTimeout(timeoutCtx, testLogger, check, interval)
+
+	assert.Equal(t, sentinelErr, err, "expected sentinel error from second call, not the abuse rate limit error")
+	assert.Equal(t, 2, calls)
+	assert.GreaterOrEqual(t, secondCallAt.Sub(firstCallAt), retryAfter, "second call should not happen before RetryAfter elapses")
+}
+
+// TestAbuseRateLimitFallsBackToInterval tests that RunUntilCancelledOrTimeout
+// falls back to the recheck interval when RetryAfter is zero (both Retry-After
+// and X-RateLimit-Reset headers were absent from the GitHub response).
+func TestAbuseRateLimitFallsBackToInterval(t *testing.T) {
+	ctx := t.Context()
+	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	interval := 50 * time.Millisecond
+	var firstCallAt time.Time
+	var secondCallAt time.Time
+	sentinelErr := fmt.Errorf("sentinel: second call succeeded")
+
+	calls := 0
+	check := &TestCheck{
+		fn: func() error {
+			calls++
+			if calls == 1 {
+				firstCallAt = time.Now()
+				return &gh.GitHubAbuseRateLimitError{
+					RetryAfter: 0, // both headers absent
+				}
+			}
+			secondCallAt = time.Now()
+			return sentinelErr
+		},
+	}
+
+	err := RunUntilCancelledOrTimeout(timeoutCtx, testLogger, check, interval)
+
+	assert.Equal(t, sentinelErr, err, "expected sentinel error from second call, not the abuse rate limit error")
+	assert.Equal(t, 2, calls)
+	assert.GreaterOrEqual(t, secondCallAt.Sub(firstCallAt), interval, "second call should not happen before interval elapses")
+}
+
+// TestPrimaryRateLimitContextCancellation tests that if the context is already
+// cancelled when a GitHubRateLimitError is encountered, the function exits with
+// "Timeout reached" and does not retry.
+func TestPrimaryRateLimitContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // cancel right away
+
+	interval := 50 * time.Millisecond
+	calls := 0
+	check := &TestCheck{
+		fn: func() error {
+			calls++
+			return &gh.GitHubRateLimitError{
+				ResetTime: time.Now().Add(2 * time.Second), // far enough away that ticker can't race ctx.Done
+			}
+		},
+	}
+
+	err := RunUntilCancelledOrTimeout(ctx, testLogger, check, interval)
+
+	assert.EqualError(t, err, "Timeout reached")
+	assert.Equal(t, 1, calls, "Check should be called once but not retried after cancellation")
+}
+
+// TestAbuseRateLimitContextCancellation tests that if the context is already
+// cancelled when a GitHubAbuseRateLimitError is encountered, the function exits
+// with "Timeout reached" and does not retry.
+func TestAbuseRateLimitContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // cancel right away
+
+	interval := 50 * time.Millisecond
+	calls := 0
+	check := &TestCheck{
+		fn: func() error {
+			calls++
+			return &gh.GitHubAbuseRateLimitError{
+				RetryAfter: time.Second, // far enough away that ticker can't race ctx.Done
+			}
+		},
+	}
+
+	err := RunUntilCancelledOrTimeout(ctx, testLogger, check, interval)
+
+	assert.EqualError(t, err, "Timeout reached")
+	assert.Equal(t, 1, calls, "Check should be called once but not retried after cancellation")
+}
+
 func TestGlobalTimeout(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	timeoutCtx, cancel := context.WithTimeout(ctx, 0)
 	defer cancel()
 


### PR DESCRIPTION
If the check runs into a rate limit, it should still retry in order not to disrupt the whole workflow.

Resolves https://github.com/grafana/wait-for-github/issues/508