### PR TITLE
chore: mark test private-key as such

### DIFF
--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -92,7 +92,7 @@ func TestNewGithubClientWithAppAuthentication(t *testing.T) {
 		InstallationID: 123,
 		AppID:          456,
 		// generate this with: openssl genrsa 32 2>/dev/null | awk 1 ORS='\\n'
-		PrivateKey: []byte("-----BEGIN RSA PRIVATE KEY-----\nMC0CAQACBQD7J5Q9AgMBAAECBB6C8NkCAwD+JwIDAPz7AgMA1xcCAkoZAgMAwE8=\n-----END RSA PRIVATE KEY-----"),
+		PrivateKey: []byte("-----BEGIN RSA PRIVATE KEY-----\nMC0CAQACBQD7J5Q9AgMBAAECBB6C8NkCAwD+JwIDAPz7AgMA1xcCAkoZAgMAwE8=\n-----END RSA PRIVATE KEY-----"), // trufflehog:ignore
 	}
 	pendingRecheckTime := 1 * time.Second
 


### PR DESCRIPTION
This addresses a trufflehog finding from
https://github.com/grafana/wait-for-github/pull/510