### PR TITLE
feat(pr): add --auto-merge-method to choose merge method

### DIFF
--- a/cmd/wait-for-github/pr.go
+++ b/cmd/wait-for-github/pr.go
@@ -48,11 +48,12 @@ type prConfig struct {
 	repo  string
 	pr    int
 
-	commitInfoFile string
-	excludes       []string
-	actionRetries  int
-	autoMerge      bool
-	writer         fileWriter
+	commitInfoFile  string
+	excludes        []string
+	actionRetries   int
+	autoMerge       bool
+	autoMergeMethod string
+	writer          fileWriter
 }
 
 var (
@@ -129,14 +130,15 @@ func parsePRArguments(ctx context.Context, cmd *cli.Command, logger *slog.Logger
 	}
 
 	return prConfig{
-		owner:          owner,
-		repo:           repo,
-		pr:             n,
-		commitInfoFile: cmd.String("commit-info-file"),
-		excludes:       excludes,
-		actionRetries:  int(cmd.Int("action-retries")),
-		autoMerge:      cmd.Bool("auto-merge"),
-		writer:         osFileWriter{},
+		owner:           owner,
+		repo:            repo,
+		pr:              n,
+		commitInfoFile:  cmd.String("commit-info-file"),
+		excludes:        excludes,
+		actionRetries:   int(cmd.Int("action-retries")),
+		autoMerge:       cmd.Bool("auto-merge"),
+		autoMergeMethod: cmd.String("auto-merge-method"),
+		writer:          osFileWriter{},
 	}, nil
 }
 
@@ -219,11 +221,11 @@ func (pr *prCheck) Check(ctx context.Context) error {
 	}
 
 	if pr.autoMerge && status == github.CIStatusPassed {
-		pr.logger.InfoContext(ctx, "CI passed and auto-merge is enabled, merging PR")
+		pr.logger.InfoContext(ctx, "CI passed and auto-merge is enabled, merging PR", "method", pr.autoMergeMethod)
 		// Pass sha to prevent merging a different commit than the one CI ran on.
 		// Merge failures (conflicts, branch protection) are retried on each poll;
 		// the global timeout bounds how long we wait.
-		if err := pr.githubClient.MergePR(ctx, pr.owner, pr.repo, pr.pr, sha); err != nil {
+		if err := pr.githubClient.MergePR(ctx, pr.owner, pr.repo, pr.pr, sha, pr.autoMergeMethod); err != nil {
 			pr.logger.WarnContext(ctx, "failed to merge PR, will retry on next poll", "error", err)
 		} else {
 			pr.logger.InfoContext(ctx, "PR merge requested, waiting for GitHub to confirm")
@@ -282,6 +284,22 @@ func prCommand(cfg *config) *cli.Command {
 				Sources: cli.NewValueSourceChain(
 					cli.EnvVar("GITHUB_AUTO_MERGE"),
 				),
+			},
+			&cli.StringFlag{
+				Name:  "auto-merge-method",
+				Usage: "Merge method to use when --auto-merge is enabled (merge, squash, rebase). Defaults to merge.",
+				Value: "merge",
+				Sources: cli.NewValueSourceChain(
+					cli.EnvVar("GITHUB_AUTO_MERGE_METHOD"),
+				),
+				Validator: func(s string) error {
+					switch s {
+					case "merge", "squash", "rebase":
+						return nil
+					default:
+						return fmt.Errorf("invalid merge method %q: must be one of merge, squash, rebase", s)
+					}
+				},
 			},
 		},
 		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {

--- a/cmd/wait-for-github/pr_test.go
+++ b/cmd/wait-for-github/pr_test.go
@@ -45,8 +45,9 @@ type fakeGithubClientPRCheck struct {
 	RerunCount        int
 	HasRunsInProgress bool
 	RerunCalledCount  int
-	MergeCalledCount   int
-	MergeCalledWithSHA string
+	MergeCalledCount      int
+	MergeCalledWithSHA    string
+	MergeCalledWithMethod string
 }
 
 func (fg *fakeGithubClientPRCheck) IsPRMergedOrClosed(ctx context.Context, owner, repo string, pr int) (string, bool, int64, error) {
@@ -69,9 +70,10 @@ func (fg *fakeGithubClientPRCheck) RerunFailedWorkflowsForCommit(ctx context.Con
 	return fg.RerunCount, fg.HasRunsInProgress, fg.rerunFailedWorkflowsError
 }
 
-func (fg *fakeGithubClientPRCheck) MergePR(ctx context.Context, owner, repo string, pr int, sha string) error {
+func (fg *fakeGithubClientPRCheck) MergePR(ctx context.Context, owner, repo string, pr int, sha, mergeMethod string) error {
 	fg.MergeCalledCount++
 	fg.MergeCalledWithSHA = sha
+	fg.MergeCalledWithMethod = mergeMethod
 	return fg.mergePRError
 }
 
@@ -79,13 +81,15 @@ func TestPRCheck(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name             string
-		fakeClient       fakeGithubClientPRCheck
-		actionRetries    int
+		name              string
+		fakeClient        fakeGithubClientPRCheck
+		actionRetries     int
 		autoMerge         bool
+		autoMergeMethod   string
 		expectedExitCode  *int
 		expectMergeCalled bool
 		expectMergeSHA    string
+		expectMergeMethod string
 	}{
 		{
 			name: "PR is merged",
@@ -162,15 +166,41 @@ func TestPRCheck(t *testing.T) {
 			},
 		},
 		{
-			name: "CI passed with auto-merge, merge succeeds",
+			name: "CI passed with auto-merge squash, merge succeeds",
 			fakeClient: fakeGithubClientPRCheck{
 				HeadSHA:  "abc123",
 				CIStatus: github.CIStatusPassed,
 			},
 			autoMerge:         true,
+			autoMergeMethod:   "squash",
 			expectMergeCalled: true,
 			expectMergeSHA:    "abc123",
+			expectMergeMethod: "squash",
 			// No exit code - continues polling to detect merge
+		},
+		{
+			name: "CI passed with auto-merge rebase, merge succeeds",
+			fakeClient: fakeGithubClientPRCheck{
+				HeadSHA:  "abc123",
+				CIStatus: github.CIStatusPassed,
+			},
+			autoMerge:         true,
+			autoMergeMethod:   "rebase",
+			expectMergeCalled: true,
+			expectMergeSHA:    "abc123",
+			expectMergeMethod: "rebase",
+		},
+		{
+			name: "CI passed with auto-merge, default method",
+			fakeClient: fakeGithubClientPRCheck{
+				HeadSHA:  "abc123",
+				CIStatus: github.CIStatusPassed,
+			},
+			autoMerge:         true,
+			autoMergeMethod:   "merge",
+			expectMergeCalled: true,
+			expectMergeSHA:    "abc123",
+			expectMergeMethod: "merge",
 		},
 		{
 			name: "CI passed with auto-merge, merge fails",
@@ -180,8 +210,10 @@ func TestPRCheck(t *testing.T) {
 				mergePRError: fmt.Errorf("merge failed"),
 			},
 			autoMerge:         true,
+			autoMergeMethod:   "squash",
 			expectMergeCalled: true,
 			expectMergeSHA:    "abc123",
+			expectMergeMethod: "squash",
 			// No exit code - continues polling and will retry
 		},
 		{
@@ -189,7 +221,8 @@ func TestPRCheck(t *testing.T) {
 			fakeClient: fakeGithubClientPRCheck{
 				CIStatus: github.CIStatusPending,
 			},
-			autoMerge: true,
+			autoMerge:       true,
+			autoMergeMethod: "squash",
 			// No exit code, no merge - waiting for CI to finish
 		},
 		{
@@ -197,7 +230,6 @@ func TestPRCheck(t *testing.T) {
 			fakeClient: fakeGithubClientPRCheck{
 				CIStatus: github.CIStatusPassed,
 			},
-			autoMerge: false,
 			// No exit code, no merge
 		},
 		{
@@ -205,7 +237,8 @@ func TestPRCheck(t *testing.T) {
 			fakeClient: fakeGithubClientPRCheck{
 				CIStatus: github.CIStatusUnknown,
 			},
-			autoMerge: true,
+			autoMerge:       true,
+			autoMergeMethod: "merge",
 			// No exit code, no merge — only CIStatusPassed triggers auto-merge
 		},
 	}
@@ -222,11 +255,12 @@ func TestPRCheck(t *testing.T) {
 			cancel()
 
 			prConfig := prConfig{
-				owner:         "owner",
-				repo:          "repo",
-				pr:            1,
-				actionRetries: tt.actionRetries,
-				autoMerge:     tt.autoMerge,
+				owner:           "owner",
+				repo:            "repo",
+				pr:              1,
+				actionRetries:   tt.actionRetries,
+				autoMerge:       tt.autoMerge,
+				autoMergeMethod: tt.autoMergeMethod,
 			}
 
 			err := checkPRMerged(ctx, fakePRStatusChecker, cfg, &prConfig)
@@ -242,6 +276,9 @@ func TestPRCheck(t *testing.T) {
 				require.Greater(t, fakePRStatusChecker.MergeCalledCount, 0, "expected MergePR to be called")
 				if tt.expectMergeSHA != "" {
 					require.Equal(t, tt.expectMergeSHA, fakePRStatusChecker.MergeCalledWithSHA, "expected MergePR to be called with head SHA")
+				}
+				if tt.expectMergeMethod != "" {
+					require.Equal(t, tt.expectMergeMethod, fakePRStatusChecker.MergeCalledWithMethod, "expected MergePR to be called with merge method")
 				}
 			} else {
 				require.Equal(t, 0, fakePRStatusChecker.MergeCalledCount, "expected MergePR not to be called")

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -70,7 +70,7 @@ type RerunFailedWorkflows interface {
 }
 
 type MergePR interface {
-	MergePR(ctx context.Context, owner, repo string, pr int, sha string) error
+	MergePR(ctx context.Context, owner, repo string, pr int, sha, mergeMethod string) error
 }
 
 type CheckCIStatus interface {
@@ -424,11 +424,31 @@ func (c GHClient) GetPRHeadSHA(ctx context.Context, owner, repo string, prNumber
 	return pr.GetHead().GetSHA(), nil
 }
 
-func (c GHClient) MergePR(ctx context.Context, owner, repo string, prNumber int, sha string) error {
+func (c GHClient) MergePR(ctx context.Context, owner, repo string, prNumber int, sha, mergeMethod string) error {
 	result, resp, err := c.client.PullRequests.Merge(ctx, owner, repo, prNumber, "", &github.PullRequestOptions{
-		SHA: sha,
+		SHA:         sha,
+		MergeMethod: mergeMethod,
 	})
 	if err != nil {
+		var ghErr *github.ErrorResponse
+		if errors.As(err, &ghErr) {
+			attrs := []any{
+				"sha", sha,
+				"merge_method", mergeMethod,
+				"status", ghErr.Response.StatusCode,
+				"message", ghErr.Message,
+				"documentation_url", ghErr.DocumentationURL,
+			}
+			for i, e := range ghErr.Errors {
+				attrs = append(attrs,
+					fmt.Sprintf("errors[%d].resource", i), e.Resource,
+					fmt.Sprintf("errors[%d].field", i), e.Field,
+					fmt.Sprintf("errors[%d].code", i), e.Code,
+					fmt.Sprintf("errors[%d].message", i), e.Message,
+				)
+			}
+			c.logger.ErrorContext(ctx, "merge PR API error", attrs...)
+		}
 		return fmt.Errorf("failed to merge PR: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

Adds a new `--auto-merge-method` flag (env: `GITHUB_AUTO_MERGE_METHOD`) that controls which merge method is used when `--auto-merge` is enabled. Accepts `merge`, `squash`, or `rebase`; defaults to `merge`.

`--auto-merge` remains a boolean flag, so existing usage is unchanged.