### PR TITLE
build: bump Go to 1.26.2 and Alpine to 3.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM} golang:1.25.5-alpine3.21@sha256:b4dbd292a0852331c89dfd64e84d16811f3e3aae4c73c13d026c4d200715aff6 AS builder
+FROM --platform=${BUILDPLATFORM} golang:1.26.2-alpine3.23@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS builder
 
 # Dependencies required to run the race detector
 RUN \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/wait-for-github
 
-go 1.25.0
+go 1.26.2
 
 require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.18.0


### PR DESCRIPTION


# CVEs

https://ops.grafana-ops.net/a/grafana-vulnerabilityobs-app/projects/860/version/8510

## Critical

- [CVE-2025-68121: crypto/tls session resumption ignores CA changes](https://ops.grafana-ops.net/a/grafana-vulnerabilityobs-app/projects/860/version/8510/cve/39528846)


### Highs

- [CVE-2026-25679: net/url accepts arbitrary text before IPv6 literals in hostname](https://ops.grafana-ops.net/a/grafana-vulnerabilityobs-app/projects/860/version/8510/cve/47665551)                                                                                                                             
- [CVE-2025-58183: archive/tar unbounded allocation when parsing GNU sparse map](https://ops.grafana-ops.net/a/grafana-vulnerabilityobs-app/projects/860/version/8510/cve/16565805)                                                                                                                                
- [CVE-2025-61729: crypto/x509 denial of service via excessive resource consumption from crafted certificate ](https://ops.grafana-ops.net/a/grafana-vulnerabilityobs-app/projects/860/version/8510/cve/24719613)                                                                                                  
- [CVE-2025-61726: net/url memory exhaustion in query parameter parsing](https://ops.grafana-ops.net/a/grafana-vulnerabilityobs-app/projects/860/version/8510/cve/37823148)                                                                                                                                        
- [CVE-2025-61728: archive/zip excessive CPU consumption when building archive index](https://ops.grafana-ops.net/a/grafana-vulnerabilityobs-app/projects/860/version/8510/cve/37823150)                                                                                                                           
- [CVE-2026-32280: crypto/x509 denial of service in certificate chain building](https://ops.grafana-ops.net/a/grafana-vulnerabilityobs-app/projects/860/version/8510/cve/54726019)
- [CVE-2026-32281: crypto/x509 denial of service via inefficient certificate chain validation](https://ops.grafana-ops.net/a/grafana-vulnerabilityobs-app/projects/860/version/8510/cve/54726020)                                                                                                                  
- [CVE-2026-32283: crypto/tls denial of service via multiple TLS 1.3 key update messages ](https://ops.grafana-ops.net/a/grafana-vulnerabilityobs-app/projects/860/version/8510/cve/54726022)