### PR TITLE
feat(pr): add --exit-on-conflict to stop waiting on unmergeable PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,10 @@ Default is `30s`.
 
 Ignore failed CI checks and continue waiting for PR to be closed or merged. Only used when `wait-for` is set to `"pr"`. Optional. Default is `false`.
 
+#### `exit-on-conflict`
+
+Exit with code `1` when the PR conflicts with its base branch and cannot be merged without intervention. Useful for automation that supersedes conflicted PRs instead of repairing them, where waiting for the timeout only delays the outcome. Only used when `wait-for` is set to `"pr"`. Optional. Default is `false`.
+
 #### `owner`
 
 GitHub repo owner. Optional. Default is the current repository's owner,

--- a/cmd/wait-for-github/pr.go
+++ b/cmd/wait-for-github/pr.go
@@ -51,6 +51,7 @@ type prConfig struct {
 	commitInfoFile  string
 	excludes        []string
 	ignoreFailedCI  bool
+	exitOnConflict  bool
 	actionRetries   int
 	autoMerge       bool
 	autoMergeMethod string
@@ -137,6 +138,7 @@ func parsePRArguments(ctx context.Context, cmd *cli.Command, logger *slog.Logger
 		commitInfoFile:  cmd.String("commit-info-file"),
 		excludes:        excludes,
 		ignoreFailedCI:  cmd.Bool("ignore-failed-ci"),
+		exitOnConflict:  cmd.Bool("exit-on-conflict"),
 		actionRetries:   int(cmd.Int("action-retries")),
 		autoMerge:       cmd.Bool("auto-merge"),
 		autoMergeMethod: cmd.String("auto-merge-method"),
@@ -153,6 +155,7 @@ type commitInfo struct {
 
 type checkMergedAndOverallCI interface {
 	github.CheckPRMerged
+	github.CheckPRMergeableState
 	github.GetPRHeadSHA
 	github.CheckOverallCIStatus
 	github.RerunFailedWorkflows
@@ -164,6 +167,7 @@ type prCheck struct {
 	githubClient checkMergedAndOverallCI
 	logger       *slog.Logger
 	retriesDone  int
+	dirtyPolls   int
 }
 
 func (pr *prCheck) Check(ctx context.Context) error {
@@ -197,6 +201,26 @@ func (pr *prCheck) Check(ctx context.Context) error {
 
 	if closed {
 		return cli.Exit("PR is closed", 1)
+	}
+
+	if pr.exitOnConflict {
+		state, err := pr.githubClient.GetPRMergeableState(ctx, pr.owner, pr.repo, pr.pr)
+		if err != nil {
+			return err
+		}
+
+		// GitHub computes mergeability lazily and can briefly report "dirty"
+		// while a background merge check runs, so require it to be stable
+		// across consecutive polls before giving up.
+		if state == "dirty" {
+			pr.dirtyPolls++
+			if pr.dirtyPolls >= 3 {
+				pr.logger.InfoContext(ctx, "PR conflicts with its base branch, exiting")
+				return cli.Exit("PR cannot be merged: the branch conflicts with its base", 1)
+			}
+		} else {
+			pr.dirtyPolls = 0
+		}
 	}
 
 	if pr.ignoreFailedCI {
@@ -283,6 +307,15 @@ func prCommand(cfg *config) *cli.Command {
 				Value: false,
 				Sources: cli.NewValueSourceChain(
 					cli.EnvVar("GITHUB_IGNORE_FAILED_CI"),
+				),
+			},
+			&cli.BoolFlag{
+				Name: "exit-on-conflict",
+				Usage: "Exit with code 1 when the PR conflicts with its base branch and cannot " +
+					"be merged without intervention. Defaults to false.",
+				Value: false,
+				Sources: cli.NewValueSourceChain(
+					cli.EnvVar("GITHUB_EXIT_ON_CONFLICT"),
 				),
 			},
 			&cli.IntFlag{

--- a/cmd/wait-for-github/pr_test.go
+++ b/cmd/wait-for-github/pr_test.go
@@ -42,6 +42,9 @@ type fakeGithubClientPRCheck struct {
 	rerunFailedWorkflowsError error
 	mergePRError              error
 
+	MergeableState         string
+	getMergeableStateError error
+
 	CIStatus              github.CIStatus
 	RerunCount            int
 	HasRunsInProgress     bool
@@ -53,6 +56,10 @@ type fakeGithubClientPRCheck struct {
 
 func (fg *fakeGithubClientPRCheck) IsPRMergedOrClosed(ctx context.Context, owner, repo string, pr int) (string, bool, int64, error) {
 	return fg.MergedCommit, fg.Closed, fg.MergedAt, fg.isPRMergedError
+}
+
+func (fg *fakeGithubClientPRCheck) GetPRMergeableState(ctx context.Context, owner, repo string, pr int) (string, error) {
+	return fg.MergeableState, fg.getMergeableStateError
 }
 
 func (fg *fakeGithubClientPRCheck) GetPRHeadSHA(ctx context.Context, owner, repo string, pr int) (string, error) {
@@ -560,5 +567,48 @@ func TestParsePRArguments(t *testing.T) {
 			finalArgs = append(finalArgs, tt.args...)
 			_ = rootCmd.Run(ctx, finalArgs)
 		})
+	}
+}
+
+func TestPRCheckExitOnConflict(t *testing.T) {
+	t.Parallel()
+
+	fakeClient := &fakeGithubClientPRCheck{
+		MergeableState: "dirty",
+		CIStatus:       github.CIStatusPending,
+	}
+
+	pr := &prCheck{
+		prConfig: prConfig{
+			owner:          "owner",
+			repo:           "repo",
+			pr:             1,
+			exitOnConflict: true,
+			ignoreFailedCI: true,
+		},
+		githubClient: fakeClient,
+		logger:       testLogger,
+	}
+
+	// The first two dirty observations keep waiting, the third exits.
+	for i := 0; i < 2; i++ {
+		if err := pr.Check(context.Background()); err != nil {
+			t.Fatalf("poll %d: want continue, got %v", i+1, err)
+		}
+	}
+	err := pr.Check(context.Background())
+	exitErr, ok := err.(cli.ExitCoder)
+	if !ok || exitErr.ExitCode() != 1 {
+		t.Fatalf("want exit code 1 after three dirty polls, got %v", err)
+	}
+
+	// A clean observation resets the counter.
+	pr.dirtyPolls = 2
+	fakeClient.MergeableState = "clean"
+	if err := pr.Check(context.Background()); err != nil {
+		t.Fatalf("clean poll: want continue, got %v", err)
+	}
+	if pr.dirtyPolls != 0 {
+		t.Fatalf("want dirtyPolls reset to 0, got %d", pr.dirtyPolls)
 	}
 }

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -49,6 +49,13 @@ type CheckPRMerged interface {
 	IsPRMergedOrClosed(ctx context.Context, owner, repo string, pr int) (string, bool, int64, error)
 }
 
+type CheckPRMergeableState interface {
+	// GetPRMergeableState returns GitHub's computed mergeable_state for the PR,
+	// for example "dirty" when the branch conflicts with its base. The value is
+	// "unknown" while GitHub has not finished computing mergeability.
+	GetPRMergeableState(ctx context.Context, owner, repo string, pr int) (string, error)
+}
+
 type GetPRHeadSHA interface {
 	GetPRHeadSHA(ctx context.Context, owner, repo string, pr int) (string, error)
 }
@@ -422,6 +429,20 @@ func (c GHClient) IsPRMergedOrClosed(ctx context.Context, owner, repo string, pr
 	}
 
 	return sha, pr.GetState() == "closed", mergedAt, nil
+}
+
+func (c GHClient) GetPRMergeableState(ctx context.Context, owner, repo string, prNumber int) (string, error) {
+	pr, resp, err := c.client.PullRequests.Get(ctx, owner, repo, prNumber)
+	if err != nil {
+		return "", fmt.Errorf("failed to query GitHub: %w", err)
+	}
+
+	respErr := c.handleResponseError(resp, "GetPullRequest", owner, repo)
+	if respErr != nil {
+		return "", respErr
+	}
+
+	return pr.GetMergeableState(), nil
 }
 
 func (c GHClient) GetPRHeadSHA(ctx context.Context, owner, repo string, prNumber int) (string, error) {


### PR DESCRIPTION
A PR that conflicts with its base cannot merge without intervention, and GitHub runs no CI on it, so the `pr` wait sees an open PR with no failed checks and polls until the timeout. In pipelines where a conflicted PR means it was superseded by a newer write — automated deploy PRs updating one file, for example — the wait only delays the real outcome, and anything serialised behind the waiting workflow is blocked with it. We hit this with a rollout workflow holding a concurrency mutex for five hours against a deploy PR that a sibling pipeline had already superseded.

`--exit-on-conflict` (default false) exits with code 1 when GitHub reports the PR's `mergeable_state` as `dirty` on three consecutive polls. The consecutive-polls guard covers GitHub computing mergeability lazily, where a single poll can transiently report `dirty` while a background merge check runs. A clean observation resets the counter.
