### PR TITLE
chore(renovate): use go preset

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,12 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: [
+    'github>grafana/grafana-renovate-config//presets/base',
+    'github>grafana/grafana-renovate-config//presets/github-actions',
+    'github>grafana/grafana-renovate-config//presets/docker',
+    'github>grafana/grafana-renovate-config//presets/go',
+    'github>grafana/grafana-renovate-config//presets/shared-workflows',
+  ],
+  dependencyDashboard: true,
+}
+


### PR DESCRIPTION
This prevents major updates to indirect dependencies which would also require import path changes.