### PR TITLE
fix(pr): wait until auto-merge is allowed

### DIFF
--- a/cmd/wait-for-github/pr.go
+++ b/cmd/wait-for-github/pr.go
@@ -154,6 +154,7 @@ type commitInfo struct {
 type checkMergedAndOverallCI interface {
 	github.CheckPRMerged
 	github.GetPRHeadSHA
+	github.CheckPRMergeable
 	github.CheckOverallCIStatus
 	github.RerunFailedWorkflows
 	github.MergePR
@@ -227,6 +228,15 @@ func (pr *prCheck) Check(ctx context.Context) error {
 	}
 
 	if pr.autoMerge && status == github.CIStatusPassed {
+		mergeable, mergeableState, err := pr.githubClient.IsPRMergeable(ctx, pr.owner, pr.repo, pr.pr)
+		if err != nil {
+			return err
+		}
+		if !mergeable {
+			pr.logger.InfoContext(ctx, "CI passed but PR is not mergeable yet", "mergeable_state", mergeableState)
+			return nil
+		}
+
 		pr.logger.InfoContext(ctx, "CI passed and auto-merge is enabled, merging PR", "method", pr.autoMergeMethod)
 		// Pass sha to prevent merging a different commit than the one CI ran on.
 		// Merge failures (conflicts, branch protection) are retried on each poll;

--- a/cmd/wait-for-github/pr_test.go
+++ b/cmd/wait-for-github/pr_test.go
@@ -38,11 +38,15 @@ type fakeGithubClientPRCheck struct {
 
 	isPRMergedError           error
 	getPRHeadSHAError         error
+	checkPRMergeableError     error
 	getCIStatusError          error
 	rerunFailedWorkflowsError error
 	mergePRError              error
 
 	CIStatus              github.CIStatus
+	Mergeable             bool
+	MergeableState        string
+	MergeableCalledCount  int
 	RerunCount            int
 	HasRunsInProgress     bool
 	RerunCalledCount      int
@@ -60,6 +64,11 @@ func (fg *fakeGithubClientPRCheck) GetPRHeadSHA(ctx context.Context, owner, repo
 		return fg.HeadSHA, fg.getPRHeadSHAError
 	}
 	return fg.MergedCommit, fg.getPRHeadSHAError
+}
+
+func (fg *fakeGithubClientPRCheck) IsPRMergeable(ctx context.Context, owner, repo string, pr int) (bool, string, error) {
+	fg.MergeableCalledCount++
+	return fg.Mergeable, fg.MergeableState, fg.checkPRMergeableError
 }
 
 func (fg *fakeGithubClientPRCheck) GetCIStatus(ctx context.Context, owner, repo string, commitHash string, excludes []string) (github.CIStatus, error) {
@@ -188,8 +197,9 @@ func TestPRCheck(t *testing.T) {
 		{
 			name: "CI passed with auto-merge squash, merge succeeds",
 			fakeClient: fakeGithubClientPRCheck{
-				HeadSHA:  "abc123",
-				CIStatus: github.CIStatusPassed,
+				HeadSHA:   "abc123",
+				CIStatus:  github.CIStatusPassed,
+				Mergeable: true,
 			},
 			autoMerge:         true,
 			autoMergeMethod:   "squash",
@@ -201,8 +211,9 @@ func TestPRCheck(t *testing.T) {
 		{
 			name: "CI passed with auto-merge rebase, merge succeeds",
 			fakeClient: fakeGithubClientPRCheck{
-				HeadSHA:  "abc123",
-				CIStatus: github.CIStatusPassed,
+				HeadSHA:   "abc123",
+				CIStatus:  github.CIStatusPassed,
+				Mergeable: true,
 			},
 			autoMerge:         true,
 			autoMergeMethod:   "rebase",
@@ -213,8 +224,9 @@ func TestPRCheck(t *testing.T) {
 		{
 			name: "CI passed with auto-merge, default method",
 			fakeClient: fakeGithubClientPRCheck{
-				HeadSHA:  "abc123",
-				CIStatus: github.CIStatusPassed,
+				HeadSHA:   "abc123",
+				CIStatus:  github.CIStatusPassed,
+				Mergeable: true,
 			},
 			autoMerge:         true,
 			autoMergeMethod:   "merge",
@@ -227,6 +239,7 @@ func TestPRCheck(t *testing.T) {
 			fakeClient: fakeGithubClientPRCheck{
 				HeadSHA:      "abc123",
 				CIStatus:     github.CIStatusPassed,
+				Mergeable:    true,
 				mergePRError: fmt.Errorf("merge failed"),
 			},
 			autoMerge:         true,
@@ -235,6 +248,26 @@ func TestPRCheck(t *testing.T) {
 			expectMergeSHA:    "abc123",
 			expectMergeMethod: "squash",
 			// No exit code - continues polling and will retry
+		},
+		{
+			name: "CI passed with auto-merge, PR is blocked",
+			fakeClient: fakeGithubClientPRCheck{
+				HeadSHA:        "abc123",
+				CIStatus:       github.CIStatusPassed,
+				MergeableState: "blocked",
+			},
+			autoMerge:       true,
+			autoMergeMethod: "merge",
+		},
+		{
+			name: "CI passed with auto-merge, mergeability check fails",
+			fakeClient: fakeGithubClientPRCheck{
+				HeadSHA:               "abc123",
+				CIStatus:              github.CIStatusPassed,
+				checkPRMergeableError: fmt.Errorf("mergeability check failed"),
+			},
+			autoMerge:       true,
+			autoMergeMethod: "merge",
 		},
 		{
 			name: "CI pending with auto-merge, no merge attempt",

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -53,6 +53,10 @@ type GetPRHeadSHA interface {
 	GetPRHeadSHA(ctx context.Context, owner, repo string, pr int) (string, error)
 }
 
+type CheckPRMergeable interface {
+	IsPRMergeable(ctx context.Context, owner, repo string, pr int) (bool, string, error)
+}
+
 type CheckOverallCIStatus interface {
 	GetCIStatus(ctx context.Context, owner, repo string, commitHash string, excludes []string) (CIStatus, error)
 }
@@ -436,6 +440,20 @@ func (c GHClient) GetPRHeadSHA(ctx context.Context, owner, repo string, prNumber
 	}
 
 	return pr.GetHead().GetSHA(), nil
+}
+
+func (c GHClient) IsPRMergeable(ctx context.Context, owner, repo string, prNumber int) (bool, string, error) {
+	pr, resp, err := c.client.PullRequests.Get(ctx, owner, repo, prNumber)
+	if err != nil {
+		return false, "", fmt.Errorf("failed to query GitHub for PR mergeability: %w", err)
+	}
+
+	if respErr := c.handleResponseError(resp, "GetPullRequest", owner, repo); respErr != nil {
+		return false, "", respErr
+	}
+
+	mergeableState := pr.GetMergeableState()
+	return pr.GetMergeable() && mergeableState == "clean", mergeableState, nil
 }
 
 func (c GHClient) MergePR(ctx context.Context, owner, repo string, prNumber int, sha, mergeMethod string) error {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -343,6 +343,63 @@ func TestIsPRMergedOrClosed_Error(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestIsPRMergeable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		githubMergeable   bool
+		mergeableState    string
+		expectedMergeable bool
+	}{
+		{
+			name:              "clean",
+			githubMergeable:   true,
+			mergeableState:    "clean",
+			expectedMergeable: true,
+		},
+		{
+			name:            "blocked by branch protection",
+			githubMergeable: true,
+			mergeableState:  "blocked",
+		},
+		{
+			name:            "merge conflict",
+			githubMergeable: false,
+			mergeableState:  "dirty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockedHTTPClient := mock.NewMockedHTTPClient(
+				mock.WithRequestMatch(
+					mock.GetReposPullsByOwnerByRepoByPullNumber,
+					github.PullRequest{
+						Mergeable:      github.Bool(tt.githubMergeable),
+						MergeableState: github.String(tt.mergeableState),
+					},
+				),
+			)
+
+			ghClient := newClientFromMock(t, mockedHTTPClient, "")
+			mergeable, state, err := ghClient.IsPRMergeable(context.Background(), "owner", "repo", 1)
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedMergeable, mergeable)
+			require.Equal(t, tt.mergeableState, state)
+		})
+	}
+}
+
+func TestIsPRMergeable_Error(t *testing.T) {
+	t.Parallel()
+
+	ghClient := newErrorReturningClient(t)
+	_, _, err := ghClient.IsPRMergeable(context.Background(), "owner", "repo", 1)
+	require.Error(t, err)
+}
+
 func TestGetCIStatus(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -376,8 +376,8 @@ func TestIsPRMergeable(t *testing.T) {
 				mock.WithRequestMatch(
 					mock.GetReposPullsByOwnerByRepoByPullNumber,
 					github.PullRequest{
-						Mergeable:      github.Bool(tt.githubMergeable),
-						MergeableState: github.String(tt.mergeableState),
+						Mergeable:      &tt.githubMergeable,
+						MergeableState: &tt.mergeableState,
 					},
 				),
 			)


### PR DESCRIPTION
## Summary

Wait for GitHub to report an auto-merge PR as clean before calling the merge API, avoiding repeated branch-protection errors while approvals are pending.

- Keep polling for blocked, conflicting, or still-computing merge states
- Log the current mergeable state while waiting